### PR TITLE
Fix lint issues and remove duplicates

### DIFF
--- a/APY/scripts/copy-manifest.js
+++ b/APY/scripts/copy-manifest.js
@@ -1,9 +1,12 @@
-const fs = require('fs');
-const path = require('path');
+import fs from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Ruta al manifest original y destino
-const srcPath = path.join(__dirname, '../public/manifest.json');
-const destPath = path.join(__dirname, '../dist/manifest.json');
+const srcPath = join(__dirname, '../public/manifest.json');
+const destPath = join(__dirname, '../dist/manifest.json');
 
 try {
   // Leer el archivo manifest.json original
@@ -25,5 +28,5 @@ try {
   console.log('✅ manifest.json copiado y actualizado correctamente');
 } catch (error) {
   console.error('❌ Error al copiar el manifest.json:', error);
-  process.exit(1);
+  throw error;
 }

--- a/APY/src/background.js
+++ b/APY/src/background.js
@@ -1,7 +1,6 @@
 // background.js - Service Worker de la extensión
 
 // Almacena la pestaña activa de WhatsApp Web
-let whatsAppTab = null;
 
 /**
  * Busca una pestaña de WhatsApp Web abierta
@@ -81,8 +80,6 @@ function handleSendMessage(request, sender, sendResponse) {
           active: false 
         },
         (newTab) => {
-          whatsAppTab = newTab;
-          
           // Esperar a que la pestaña esté completamente cargada
           const onTabUpdated = (tabId, info, updatedTab) => {
             if (tabId === newTab.id && info.status === 'complete') {
@@ -100,8 +97,8 @@ function handleSendMessage(request, sender, sendResponse) {
       );
     }
   });
-  const waURL = `https://web.whatsapp.com/send?phone=${phoneNumber}` +
-                `&text=${encodeURIComponent(message || '')}` +
+  const waURL = `https://web.whatsapp.com/send?phone=${phone}` +
+                `&text=${encodeURIComponent(text || '')}` +
                 '&type=phone_number&app_absent=0';
   
   // Responder de inmediato para evitar el error de puerto cerrado

--- a/APY/src/components/TemplateModal.jsx
+++ b/APY/src/components/TemplateModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 
@@ -109,7 +109,6 @@ const TemplateModal = ({ isOpen, onClose, onSave, template }) => {
                 borderRadius: '4px',
                 cursor: 'pointer',
                 transition: 'all 0.2s',
-                border: 'none',
                 outline: 'none',
                 fontSize: '14px',
                 backgroundColor: '#f0f0f0',

--- a/APY/src/contentScript.js
+++ b/APY/src/contentScript.js
@@ -128,12 +128,5 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
   return false;
 });
 
-// Iniciar el script cuando el DOM esté listo
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', () => {});
-} else {
-  // Si el documento ya está cargado, ejecutar directamente
-  {}
-}
 
 console.log('APYSKY: Content script completamente inicializado');

--- a/APY/src/popup.jsx
+++ b/APY/src/popup.jsx
@@ -77,8 +77,8 @@ const validatePhone = (phone) => {
       return { valid: false, error: 'Número de teléfono inválido' };
     }
     return { valid: true, phone: phoneNumber.formatInternational() };
-  } catch (error) {
-    const cleaned = phone.replace(/[^\d\+]/g, '');
+} catch {
+    const cleaned = phone.replace(/[^\d+]/g, '');
     if (cleaned.length < 6 || cleaned.length > 20) {
       return { valid: false, error: 'Número de teléfono inválido (debe tener entre 6 y 20 dígitos)' };
     }
@@ -102,151 +102,6 @@ const hasValidNumbers = (text) => {
 };
 
 /* ------------------------------------------------------------------
-  MODAL PLANTILLAS
--------------------------------------------------------------------*/
-const TemplateModal = ({ isOpen, onClose, onSave, template = null }) => {
-  const [name, setName] = useState(template?.name || '');
-  const [content, setContent] = useState(template?.content || '');
-
-  useEffect(() => {
-    if (template) {
-      setName(template.name);
-      setContent(template.content);
-    } else {
-      setName('');
-      setContent('');
-    }
-  }, [template]);
-
-  if (!isOpen) return null;
-
-  return (
-    <div
-      style={{
-        position: 'fixed',
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-        backgroundColor: 'rgba(0,0,0,0.5)',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        zIndex: 1000,
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: 'white',
-          padding: '20px',
-          borderRadius: '8px',
-          width: '90%',
-          maxWidth: '600px',
-          maxHeight: '90vh',
-          display: 'flex',
-          flexDirection: 'column',
-        }}
-      >
-        <h3 style={{ marginTop: 0, color: '#b30000' }}>
-          {template ? 'Editar Plantilla' : 'Nueva Plantilla'}
-        </h3>
-
-        {/* Nombre */}
-        <div style={{ marginBottom: '15px' }}>
-          <label
-            style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}
-          >
-            Nombre de la plantilla:
-          </label>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              border: '1px solid #ddd',
-              borderRadius: '4px',
-              boxSizing: 'border-box',
-            }}
-            placeholder="Ej: Recordatorio de pago"
-          />
-        </div>
-
-        {/* Contenido */}
-        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', marginBottom: '15px' }}>
-          <label style={{ marginBottom: '5px', fontWeight: 'bold' }}>Contenido:</label>
-          <ReactQuill
-            theme="snow"
-            value={content}
-            onChange={setContent}
-            style={{ flex: 1, display: 'flex', flexDirection: 'column' }}
-            modules={{
-              toolbar: [
-                [{ header: [1, 2, 3, false] }],
-                ['bold', 'italic', 'underline', 'strike'],
-                [{ list: 'ordered' }, { list: 'bullet' }],
-                ['link', 'image'],
-                ['clean'],
-              ],
-            }}
-            formats={[
-              'header',
-              'bold',
-              'italic',
-              'underline',
-              'strike',
-              'list',
-              'bullet',
-              'link',
-              'image',
-            ]}
-          />
-        </div>
-
-        {/* Acciones */}
-        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-          <button
-            onClick={onClose}
-            style={{
-              padding: '8px 16px',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              transition: 'all 0.2s',
-              border: 'none',
-              outline: 'none',
-              fontSize: '14px',
-              backgroundColor: '#f0f0f0',
-              color: '#333',
-              border: '1px solid #ccc',
-              '&:hover': {
-                backgroundColor: '#e0e0e0',
-              },
-            }}
-          >
-            Cancelar
-          </button>
-          <button
-            onClick={() => onSave({ id: template?.id, name, content })}
-            disabled={!name.trim() || !content.trim()}
-            style={{
-              padding: '8px 16px',
-              backgroundColor:
-                !name.trim() || !content.trim() ? '#ccc' : '#b30000',
-              color: 'white',
-              border: 'none',
-              borderRadius: '4px',
-              cursor:
-                !name.trim() || !content.trim() ? 'not-allowed' : 'pointer',
-            }}
-          >
-            {template ? 'Actualizar' : 'Guardar'} Plantilla
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
 
 /* ------------------------------------------------------------------
   ESTILOS QUILL (inline para no depender de archivo externo)
@@ -1642,3 +1497,4 @@ const Popup = () => {
     </div>
   );
 }
+export default Popup;

--- a/APY/vite.config.js
+++ b/APY/vite.config.js
@@ -1,7 +1,5 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { fileURLToPath } from 'url';
-import babel from '@vitejs/plugin-react';
 
 // Configure React plugin with Babel for JSX
 const reactConfig = {
@@ -34,7 +32,7 @@ export default defineConfig({
           console.log('✅ Manifest copiado correctamente');
         } catch (error) {
           console.error('❌ Error copiando el manifest:', error);
-          process.exit(1);
+          throw error;
         }
       }
     },


### PR DESCRIPTION
## Summary
- remove duplicated TemplateModal component
- fix message variable names in background script
- import `useEffect` in TemplateModal and tidy styles
- convert copy-manifest.js to ES modules
- clean up content script and vite config
- add missing default export for Popup

## Testing
- `npm run lint` *(frontend)*
- `npm run lint` *(backend, fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687697a379f88320862185db69170b59